### PR TITLE
Fallback country

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ Choose whether you want the payment provider selection to happen in the checkout
 ### Merchant ID and Secret key
 
 Your OP Payment Service credentials. You can obtain the keys by registering at our [website](https://www.checkout.fi) (in Finnish only) or contact [asiakaspalvelu@checkout.fi](mailto:asiakaspalvelu@checkout.fi) directly.
+
+### Fallback Country
+
+Setup fallback country to be used if no country is provided from Woocommerce checkout. Use only if billing_country/shipping_country is removed from checkout fields.

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -273,6 +273,14 @@ final class Gateway extends \WC_Payment_Gateway
                 'label'   => __( 'Secret key', 'op-payment-service-woocommerce' ),
                 'default' => '',
             ],
+            'fallback_country'  => [
+                'title'   => __( 'Fallback country', 'op-payment-service-woocommerce' ),
+                'type'    => 'select',
+                'label'   => __( 'Fallback country', 'op-payment-service-woocommerce' ),
+                'default' => '',
+                'description' => __( 'Select country to be used as fallback if no country specified in checkout.', 'op-payment-service-woocommerce' ),
+                'options' => array_merge(['' => 'Select country'], WC()->countries->get_countries())
+            ],
         ];
     }
 
@@ -1509,7 +1517,7 @@ final class Gateway extends \WC_Payment_Gateway
             ->setPostalCode( $order->{ 'get_' . $prefix . 'postcode' }() ?? null )
             ->setCity( $order->{ 'get_' . $prefix . 'city' }() ?? null )
             ->setCounty( $order->{ 'get_' . $prefix . 'state' }() ?? null )
-            ->setCountry( $order->{ 'get_' . $prefix . 'country' }() ?? null );
+            ->setCountry( $order->{ 'get_' . $prefix . 'country' }() ?: $this->get_option( 'fallback_country', '' ) );
 
         // If we have any of the listed properties, we are good to go
         $has_values = array_filter(


### PR DESCRIPTION
- Add setting for fallback country in payment gateway settings
- Add support to send fallback country in Checkout API if no country is provided from Woocommerce checkout